### PR TITLE
Correct `fp` package name

### DIFF
--- a/pkg/fp/optional.go
+++ b/pkg/fp/optional.go
@@ -1,4 +1,4 @@
-package optional
+package fp
 
 // Optional allows for generic creation of pointers to values.
 func Optional[T any](value T) *T {


### PR DESCRIPTION
The `fp` package name and the directory name were not equal, this will make them equal.